### PR TITLE
remove Book class to match beginning state in README

### DIFF
--- a/lib/book.rb
+++ b/lib/book.rb
@@ -1,3 +1,2 @@
-class Book
 
-end
+


### PR DESCRIPTION
See: https://github.com/learn-co-curriculum/oo-basics/blob/master/README.md#running-the-tests

and

https://github.com/learn-co-curriculum/oo-basics/blob/master/README.md#defining-the-book-class